### PR TITLE
Potential fix for code scanning alert no. 19: DOM text reinterpreted as HTML

### DIFF
--- a/static/player.js
+++ b/static/player.js
@@ -406,15 +406,31 @@ document.addEventListener('DOMContentLoaded', function () {
         var isValidSrc = false;
         try {
           var srcUrl = new URL(src, window.location.origin);
-          if (srcUrl.protocol === "http:" || srcUrl.protocol === "https:") {
+          // Only allow same origin http(s): URLs, or relative URLs that aren't protocol-relative or contain dangerous schemes
+          if (
+            (srcUrl.protocol === "http:" || srcUrl.protocol === "https:") &&
+            // Only allow http(s) to this origin or a defined trusted host; you could further restrict this check.
+            (srcUrl.origin === window.location.origin)
+          ) {
             isValidSrc = true;
-          } else if (srcUrl.origin === window.location.origin && !/^(data:|javascript:|vbscript:)/i.test(src.trim())) {
-            // Allow relative URL that isn't a dangerous scheme
+          }
+          // If src is a relative URL (not absolute URL), confirm it does not start with /, // or contain dangerous patterns
+          else if (
+            src &&
+            !/^(\/\/|\/|\\)/.test(src) &&
+            !/^(data:|javascript:|vbscript:)/i.test(src.trim()) &&
+            /^[a-zA-Z0-9_\-./%]+$/.test(src)
+          ) {
             isValidSrc = true;
           }
         } catch (e) {
-          // If URL construction fails, check if it's a valid relative path
-          if (/^[^\s:\/\\]+(\.[^\s:\/\\]+)?$/.test(src) && !/^(data:|javascript:|vbscript:)/i.test(src.trim())) {
+          // If URL construction fails, fallback: accept only simple relative file names, and disallow dangerous protocols
+          if (
+            src &&
+            !/^(data:|javascript:|vbscript:)/i.test(src.trim()) &&
+            /^[a-zA-Z0-9_\-./%]+$/.test(src) &&
+            !/^(\/\/|\/|\\)/.test(src)
+          ) {
             isValidSrc = true;
           }
         }


### PR DESCRIPTION
Potential fix for [https://github.com/gauthamnair2005/ViewFlow/security/code-scanning/19](https://github.com/gauthamnair2005/ViewFlow/security/code-scanning/19)

To resolve this, further tighten and robustly enforce allowed protocols/types of video sources that can be set as the `src` attribute of the `<video>` element. Ideally, only allow http(s) URLs belonging to known origins, or *safe* relative URLs (not allowing protocol-relative, absolute paths, or any nonstandard/bad schemes).

- Update the validation of the `src` variable to ensure the only allowed sources are:
  - Absolute URLs with http or https protocol,
  - OR relative paths that do not start with dangerous sequences (`//`, `/`, `javascript:`, `data:`, etc.), and that contain only allowed characters (letters, numbers, limited symbols).
- Consider explicitly disallowing `file://`, or any URL whose protocol is not `http` or `https`.
- The code that sets `html5video.src = src` is okay as long as the above is fully enforced.
- Code changes should be in the region of lines 403–425 of `static/player.js`.

No new imports are needed, but a more robust validation function may be defined within the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
