### PR TITLE
Potential fix for code scanning alert no. 19: DOM text reinterpreted as HTML

### DIFF
--- a/static/player.js
+++ b/static/player.js
@@ -402,34 +402,32 @@ document.addEventListener('DOMContentLoaded', function () {
       if (first) {
         var src = first.getAttribute('data-src');
         
-        // Only allow http(s) URLs or relative paths (not protocols like data:, javascript:, etc)
+        // Strict whitelist: Only allow http(s) URLs (same origin) or simple relative filenames ending in allowed extensions.
         var isValidSrc = false;
+        var allowedExtensions = ['.mp4', '.webm', '.ogg'];
+        function hasAllowedExtension(s) {
+          return allowedExtensions.some(function(ext) {
+            return typeof s === 'string' && s.toLowerCase().endsWith(ext);
+          });
+        }
         try {
           var srcUrl = new URL(src, window.location.origin);
-          // Only allow same origin http(s): URLs, or relative URLs that aren't protocol-relative or contain dangerous schemes
+          // Only allow http(s) to *this* origin, extension must be allowed
           if (
             (srcUrl.protocol === "http:" || srcUrl.protocol === "https:") &&
-            // Only allow http(s) to this origin or a defined trusted host; you could further restrict this check.
-            (srcUrl.origin === window.location.origin)
-          ) {
-            isValidSrc = true;
-          }
-          // If src is a relative URL (not absolute URL), confirm it does not start with /, // or contain dangerous patterns
-          else if (
-            src &&
-            !/^(\/\/|\/|\\)/.test(src) &&
-            !/^(data:|javascript:|vbscript:)/i.test(src.trim()) &&
-            /^[a-zA-Z0-9_\-./%]+$/.test(src)
+            (srcUrl.origin === window.location.origin) &&
+            hasAllowedExtension(srcUrl.pathname)
           ) {
             isValidSrc = true;
           }
         } catch (e) {
-          // If URL construction fails, fallback: accept only simple relative file names, and disallow dangerous protocols
+          // fallback: Only allow plain relative file names with allowed extension
           if (
-            src &&
-            !/^(data:|javascript:|vbscript:)/i.test(src.trim()) &&
-            /^[a-zA-Z0-9_\-./%]+$/.test(src) &&
-            !/^(\/\/|\/|\\)/.test(src)
+            typeof src === 'string' &&
+            /^[a-zA-Z0-9_\-./%]+$/.test(src) && // simple safe chars, no directory traversal
+            !/^(\/\/|\/|\\)/.test(src) &&       // does not start as absolute
+            !/^(data:|javascript:|vbscript:)/i.test(src.trim()) && // not dangerous schemes
+            hasAllowedExtension(src)
           ) {
             isValidSrc = true;
           }
@@ -438,7 +436,7 @@ document.addEventListener('DOMContentLoaded', function () {
         if (src && isValidSrc) {
           // switch to the new source (HTML5 only)
           if (html5video) { 
-            html5video.src = src; 
+            html5video.src = src.trim(); // trim whitespace to prevent spoofing
             html5video.play(); 
             hideOverlay(); 
             hideReplayBtn();


### PR DESCRIPTION
Potential fix for [https://github.com/gauthamnair2005/ViewFlow/security/code-scanning/19](https://github.com/gauthamnair2005/ViewFlow/security/code-scanning/19)

The proper way to fix this issue is to ensure that values extracted from the DOM and used as resource URLs are strictly validated and sanitized, allowing only safe and intended values, and never allowing attacker-controlled data to control the resource in an unsafe way. For this specific scenario, the best approach is to (1) only allow a strictly defined list of allowed files and/or file types (for example, only allow `.mp4` files from the current site), or (2) allow only resources served from the same domain and over HTTPS, and check not only the domain but also the pathname and other properties.

Additionally, before assignment, it is best to set the `src` using the `HTMLVideoElement.src` property only if all checks pass, and to make sure the value cannot begin with any characters that could be interpreted as a browser-hacked scheme, such as whitespace or special characters. For defense-in-depth, one could also consider normalizing and encoding URL paths.

Given only the shown code snippet, the fix should (A) add a simple whitelist for extensions (e.g., `.mp4`, `.webm`, `.ogg`), and (B) ensure that `src` does not include any dangerous characters and does not allow URLs to outside the current origin. The code already does some of this, but the regex should be restricted to something like `/^[\w.\-/%]+\.((mp4)|(webm)|(ogg))$/i`, and the checks combined more simply.

No changes are necessary to import statements or require external libraries, as this can be managed via enhanced regexes and conditional logic.

Edit the code region beginning at line 403 (`var src = first.getAttribute('data-src');`) and in the block that follows where `src` is validated and used, enhancing the validation and restricting extension acceptance.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
